### PR TITLE
Create CI/CD pipeline

### DIFF
--- a/.github/workflows/cicd_pipeline.yml
+++ b/.github/workflows/cicd_pipeline.yml
@@ -1,0 +1,41 @@
+name: cicd_pipeline
+
+on:
+  push:
+    branches:
+       -"main"
+    tags:
+       - publish
+    
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout 
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/cicd_pipeline:latest
+      
+     
+  


### PR DESCRIPTION
GitHub workflow implements CI/CD by updating Docker container image with every push to master that has a -publish tag.